### PR TITLE
ci: publish build artifacts #5 (#48)

### DIFF
--- a/.github/workflows/10-build.yaml
+++ b/.github/workflows/10-build.yaml
@@ -1,14 +1,19 @@
 ---
 
-name: Convert and Release
+name: build
 
 on:
   push:
     branches:
       - main
       - dev
-      - v*
-  workflow_dispatch:
+      - 'v[0-9]?*'
+
+  pull_request:
+    branches:
+      - '**'
+
+  workflow_dispatch: {}
 
 env:
   srcdir: src
@@ -17,7 +22,7 @@ env:
   prefix: richard_henning-professional_resume
 
 jobs:
-  convert:
+  build:
     runs-on: ubuntu-latest
 
     defaults:
@@ -109,96 +114,8 @@ jobs:
             --output="./${{ env.builddir }}/${{ env.prefix }}.html"
             "./${{ env.srcdir }}/${{ env.srcdoc }}"
 
-      - name: Upload artifacts
+      - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.prefix }}-${{ steps.get_repometa.outputs.short_sha }}
           path: ${{ env.builddir }}/*
-
-  release:
-    needs: convert
-    runs-on: ubuntu-latest
-
-    defaults:
-      run:
-        shell: bash
-        working-directory: ${{ github.workspace }}
-
-    permissions:
-      contents: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Get additional git repository metatdata
-        id: get_repometa
-        run: |
-          echo "short_sha=$( git rev-parse --short ${{ github.sha }} )" >> $GITHUB_OUTPUT
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ env.prefix }}-${{ steps.get_repometa.outputs.short_sha }}
-          path: ./artifacts
-
-      - name: Create GitHub Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: release/${{ steps.get_repometa.outputs.short_sha }}
-          release_name: release/${{ steps.get_repometa.outputs.short_sha }}
-          draft: true
-          prerelease: true
-
-      - name: Upload Markdown assets
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./artifacts/${{ env.prefix }}.md
-          asset_name: ${{ env.prefix }}.md
-          asset_content_type: text/markdown
-
-      - name: Upload PDF assets
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./artifacts/${{ env.prefix }}.pdf
-          asset_name: ${{ env.prefix }}.pdf
-          asset_content_type: application/pdf
-
-      - name: Upload DOCX assets
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./artifacts/${{ env.prefix }}.docx
-          asset_name: ${{ env.prefix }}.docx
-          asset_content_type: application/vnd.openxmlformats-officedocument.wordprocessingml.document
-
-      - name: Upload HTML assets
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./artifacts/${{ env.prefix }}.html
-          asset_name: ${{ env.prefix }}.html
-          asset_content_type: text/html
-
-      - name: Upload build metadata
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./artifacts/BUILDMETA.json
-          asset_name: BUILDMETA.json
-          asset_content_type: application/json

--- a/.github/workflows/10-lint.yaml
+++ b/.github/workflows/10-lint.yaml
@@ -1,22 +1,28 @@
 ---
 
-name: Style & Syntax Checks
+name: lint
 
 on:
   push:
     branches:
       - main
+      - dev
+      - 'v[0-9]?*'
+
   pull_request:
     branches:
       - '**'
-  workflow_dispatch:
+
+  workflow_dispatch: {}
 
 jobs:
-  style-check-markdownlint:
+  markdownlint:
     runs-on: ubuntu-latest
+
     permissions:
       contents: read
       pull-requests: write
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -28,11 +34,13 @@ jobs:
           reporter: github-pr-review
           fail_level: error
 
-  style-check-yamllint:
+  yamllint:
     runs-on: ubuntu-latest
+
     permissions:
       contents: read
       pull-requests: write
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -44,11 +52,13 @@ jobs:
           reporter: github-pr-review
           fail_level: error
 
-  style-check-biome:
+  biome:
     runs-on: ubuntu-latest
+
     permissions:
       contents: read
       pull-requests: write
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -63,11 +73,13 @@ jobs:
           ## it can be removed when the action is updated to >=v2.
           fail_on_error: true
 
-  style-check-misspell:
+  misspell:
     runs-on: ubuntu-latest
+
     permissions:
       contents: read
       pull-requests: write
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/20-release.yaml
+++ b/.github/workflows/20-release.yaml
@@ -1,0 +1,133 @@
+---
+
+name: release
+
+on:
+  workflow_run:
+    workflows: [build]
+    types: [completed]
+
+    branches:
+      - main
+      - dev
+      - 'v[0-9]?*'
+
+  workflow_dispatch: {}
+
+env:
+  assetsdir: artifacts
+  prefix: richard_henning-professional_resume
+
+jobs:
+  on-success:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: |
+          cat <<-__END__
+            `release` triggered by successful completion of `build` workflow.
+
+            trigger-event: ${{ toJson(github.event.workflow_run) }}
+          __END__
+
+  release:
+    needs: on-success
+
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+        working-directory: ${{ github.workspace }}
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Get additional git repository metatdata
+        id: get_repometa
+        run: |
+          echo "short_sha=$( git rev-parse --short ${{ github.sha }} )" >> $GITHUB_OUTPUT
+
+      - name: Fetch build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.prefix }}-${{ steps.get_repometa.outputs.short_sha }}
+          path: ./${{ env.assetsdir }}
+
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@v1
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+        with:
+          tag_name: release/${{ steps.get_repometa.outputs.short_sha }}
+          release_name: release/${{ steps.get_repometa.outputs.short_sha }}
+          prerelease: ${{github.event.workflow_run.head_branch != 'main'}}
+          draft: true
+
+      - name: Release Markdown assets
+        uses: actions/upload-release-asset@v1
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./${{ env.assetsdir }}/${{ env.prefix }}.md
+          asset_name: ${{ env.prefix }}.md
+          asset_content_type: text/markdown
+
+      - name: Release PDF assets
+        uses: actions/upload-release-asset@v1
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./${{ env.assetsdir }}/${{ env.prefix }}.pdf
+          asset_name: ${{ env.prefix }}.pdf
+          asset_content_type: application/pdf
+
+      - name: Release DOCX assets
+        uses: actions/upload-release-asset@v1
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./${{ env.assetsdir }}/${{ env.prefix }}.docx
+          asset_name: ${{ env.prefix }}.docx
+          asset_content_type: application/vnd.openxmlformats-officedocument.wordprocessingml.document
+
+      - name: Release HTML assets
+        uses: actions/upload-release-asset@v1
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./${{ env.assetsdir }}/${{ env.prefix }}.html
+          asset_name: ${{ env.prefix }}.html
+          asset_content_type: text/html
+
+      - name: Release BUILDMETA assets
+        uses: actions/upload-release-asset@v1
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./${{ env.assetsdir }}/BUILDMETA.json
+          asset_name: BUILDMETA.json
+          asset_content_type: application/json


### PR DESCRIPTION
This PR refactors GitHub Actions workflows to separate build, lint, and release logic and to publish build artifacts upon successful builds using workflow events rather than direct push/PR triggers.

* Introduces a dedicated 20-release.yaml that fires on workflow_run completion and publishes release assets.
* Extends lint workflow (10-lint.yaml) to run on dev and version branches and adds workflow_dispatch.
* Simplifies build workflow (10-build.yaml), renames jobs, adds PR triggers, and removes embedded release steps.


* ci: publish build artifacts (closes #5)
* ci: rm unused vars
* ci: separate build workflows (closes #12) 