### PR TITLE
doc: include link to releases (#52)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ with slim budgets and a small staff.
 That experience left quite an impression, for which I owe a great debt of gratitude
 to my mentors and colleagues, several of whom have become lifelong friends.
 
-Since that time I've had the fortunate to work for a number of forward-looking tech
+Since that time I've been fortunate to work for a number of forward-looking tech
 organizations with amazing teams spanning varied domains, including Media and
 Entertainment, Public and Private Cloud, E-commerce, Internet and Data Center
 Services, Telecommunications, Web and Server Hosting, and Document Intelligence,

--- a/README.md
+++ b/README.md
@@ -1,16 +1,46 @@
 # `rhenning/resume`
 
-## Who am I?
+## FAQ
+
+### Who are you?
 
 _**Hi.**_ :wave:
 
 My name is Richard Henning—"Rich" to most—a technologist, software engineer,
-and creative hailing from Philadelphia, the _City of Brotherly Love_ and birthplace of
-the United States.
+and creative hailing from Philadelphia, _City of Brotherly Love_ and birthplace of the
+United States, where I live with my partner, daughters, and a lovable mutt.
+
+I'm a tech industry veteran with more than twenty years of experience, helping
+companies design, implement, provision, sustainably operate, and continuously
+deliver change to always-on web systems, cloud, and on-prem infrastructure at
+scale.
+
+Some amazing products and teams I've had the pleasure of working on include:
+
+* Max @ Warner Bros. Discovery
+* HBO Max @ WarnerMedia
+* Xfinity Stream and the X1 Video Platform @ Comcast/Xfinity
+* the Workarea Commerce Platform @ Weblinc Commerce
+* NeatCloud @ The Neat Company
+* Jux, LimeBits, LimeDomains, and LimeExchange @ The Lime Group
+  (LimeWire's parent organization)
+* Managed Internet services @ Fastnet & NetAxs — popular ISP/MSPs of
+  the Greater Philadelphia area, specializing in business and residential
+  Internet, web server hosting, colocation, carrier & business networking,
+  email, DNS, newsgroups, observability, disaster recovery, managed data
+  centers, and professional consulting services.
+
+### How can I download a copy of your résumé?
+
+Please visit the **[list of most recent Releases and Assets][releases]** where you can find and
+download documents suitable for viewing. PDF is the recommended format, but
+several others are provided for convenience.
+
+### How did you get involved with technology?
 
 I've been fascinated both by making things and taking them apart, in order to
 understand what makes them tick, for about as long as I can remember, much to
-the dismay of my patient and loving parents at times.
+the dismay of my patient and loving parents, at times.
 
 Perhaps that was Dad's motivation for giving the gift of a used Commodore all
 along—I might stop taking apart his turntable and guitar pedals.
@@ -29,38 +59,31 @@ hardware repurposed for server and embedded applications.
 
 Throughout my first "real" technology job after college, I continued to explore the
 application of Linux, Unix, and free software to computing problems both at home
-and at work—despite working at a largely _"Windows"_ shop—with no budget, but keen
-to reduce toil and manual process involved in day-to-day operations.
+and at work—despite it being a "_Windows_ shop"—with zero budget, but keen to
+limit the toil and manual process associated with my daily work.
 
-When _Fastnet_—a Pennsylvania-based ISP and hosting provider I very much respected—
-was seeking out Linux sysadmins, I responded to their ad, was granted an interview,
-and received an offer, which I graciously accepted.
+When _Fastnet_—a Philadelphia-area ISP and hosting provider I very much respected—
+was seeking out Linux sysadmins, I jumped at the opportunity, had an interview,
+and was thrilled to receive an offer letter, which I graciously accepted.
 
-I remained at Fastnet for about eight years—the longest stint of my career—surviving
-the dot-com boom, bust, a merger with _NetAxs_—another well-regarded Philly-area ISP—
-and two subsequent acquisitions. Some of us at Fastnet practiced what we might now
-call _"DevOps"_ and _"Pair Programming"_, organically through culture before these were
-common parlance. I owe a great debt of gratitude to my colleagues and mentors
-there, several of whom have become lifelong friends.
+I learned _so much_ during my time at Fastnet, remaining there for about eight years—
+the longest stint of my career—and surviving the dot-com boom, bust, a merger
+with _NetAxs_—another well-regarded Philly-area ISP—and two follow-up acquisitions.
+It was there I learned to apply the fundamentals of what would later become known
+as _DevOps_ and _Pair Programming_, sharing in these prototype cultures before those
+terms were in vogue. It wasn't out of deference to any sort of ideology; software
+automation and version control enabled us to reliably build, provision, operate and
+scale the infrastructure and services needed to support a rapidly-growing business,
+with slim budgets and a small staff.
 
-From that time forward I've been fortunate to work for a number of forward-looking
-tech companies with amazing teams spanning varied domains, including Media and
-Entertainment, Internet and Data Center Services, Telecommunications, Web and
-Server Hosting, Public and Private Cloud, and Document Organization, Classification,
-and Archival.
+That experience left quite an impression, for which I owe a great debt of gratitude
+to my mentors and colleagues, several of whom have become lifelong friends.
 
-A cross-section of these companies and their products includes:
-
-* **Warner Bros. Discovery** — where I worked on _**Max**_.
-* **WarnerMedia** — where I worked on _**HBO Max**_.
-* **Comcast/Xfinity** — where I worked on _**Xfinity Stream**_ and the _**X1 Video Platform**_.
-* **The Neat Company** — where I worked on _**NeatCloud**_.
-* **The Lime Group/Lime Labs** — where I worked on _**Jux, LimeBits, LimeDomains**_
-  and _**LimeExchange**_ (and _LimeWire_'s parent organization.)
-* **Fastnet & NetAxs** — popular Philadelphia-area ISPs specializing in business and
-  residential Internet, shared and dedicated web server hosting, colocation, email,
-  DNS, newsgroups, monitoring & metrics, disaster recovery, managed data centers,
-  and professional consulting services.
+Since that time I've had the fortunate to work for a number of forward-looking tech
+organizations with amazing teams spanning varied domains, including Media and
+Entertainment, Public and Private Cloud, E-commerce, Internet and Data Center
+Services, Telecommunications, Web and Server Hosting, and Document Intelligence,
+Organization, Generation, and Archival.
 
 ## Gratitude and Respect
 
@@ -77,3 +100,4 @@ not exist as they do today.
 **Thank You to all open-source contributors for your hard work and generosity.**
 
 [FOSS]: https://en.wikipedia.org/wiki/Free_and_open-source_software
+[releases]: https://github.com/rhenning/resume/releases


### PR DESCRIPTION
This PR updates the project documentation by reorganizing the introductory content into a FAQ section and including a direct link to the project's releases for résumé downloads.

* Converted the "Who am I?" section into a broader "FAQ" section.
* Updated text to add more context about the author's background and provided a link to the project's Releases.
* Provide prominent link to Releases in the README (closes #52) 
