### PR TITLE
bug: explicitly reference release trigger workflow

### DIFF
--- a/.github/workflows/20-release.yaml
+++ b/.github/workflows/20-release.yaml
@@ -10,7 +10,9 @@ on:
     branches:
       - main
       - dev
-      - 'v[0-9]?*'
+      - develop
+      - 'v[0-9]*'
+      - 'release/v[0-9]*'
 
   workflow_dispatch: {}
 
@@ -24,11 +26,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - run: |
+      - name: "`release` triggered by `build` workflow {{ github.event.workflow_run.id }}"
+        run: |
           cat <<-__END__
-            `release` triggered by successful completion of `build` workflow.
-
-            trigger-event: ${{ toJson(github.event.workflow_run) }}
+          workflow-run-event: ${{ toJson(github.event.workflow_run) }}
           __END__
 
   release:
@@ -56,6 +57,7 @@ jobs:
       - name: Fetch build artifacts
         uses: actions/download-artifact@v4
         with:
+          run-id: ${{ github.event.workflow_run.id }}
           name: ${{ env.prefix }}-${{ steps.get_repometa.outputs.short_sha }}
           path: ./${{ env.assetsdir }}
 


### PR DESCRIPTION
This PR aims to fix a bug that results in the workflow being unable to find associated assets, requiring manual publishing of releases as the current workaround.

closes #50 