### PR TITLE
ci: short SHA in artifact name & enable release

### DIFF
--- a/.github/workflows/10-build.yaml
+++ b/.github/workflows/10-build.yaml
@@ -77,7 +77,7 @@ jobs:
             --to gfm
             --metadata version-meta="${{ steps.get_repometa.outputs.short_sha }}"
             --metadata date-meta="${{ steps.get_repometa.outputs.date }}"
-            --output="./${{ env.builddir }}/${{ env.prefix }}.md"
+            --output="./${{ env.builddir }}/${{ env.prefix }}-${{ steps.get_repometa.outputs.short_sha }}.md"
             "./${{ env.srcdir }}/${{ env.srcdoc }}"
 
       - name: Convert source to PDF
@@ -89,7 +89,7 @@ jobs:
             --from gfm
             --metadata version-meta="${{ steps.get_repometa.outputs.short_sha }}"
             --metadata date-meta="${{ steps.get_repometa.outputs.date }}"
-            --output="./${{ env.builddir }}/${{ env.prefix }}.pdf"
+            --output="./${{ env.builddir }}/${{ env.prefix }}-${{ steps.get_repometa.outputs.short_sha }}.pdf"
             "./${{ env.srcdir }}/${{ env.srcdoc }}"
 
       - name: Convert source to DOCX
@@ -100,7 +100,7 @@ jobs:
             --from gfm
             --metadata version-meta="${{ steps.get_repometa.outputs.short_sha }}"
             --metadata date-meta="${{ steps.get_repometa.outputs.date }}"
-            --output="./${{ env.builddir }}/${{ env.prefix }}.docx"
+            --output="./${{ env.builddir }}/${{ env.prefix }}-${{ steps.get_repometa.outputs.short_sha }}.docx"
             "./${{ env.srcdir }}/${{ env.srcdoc }}"
 
       - name: Convert source to HTML
@@ -111,7 +111,7 @@ jobs:
             --from gfm
             --metadata version-meta="${{ steps.get_repometa.outputs.short_sha }}"
             --metadata date-meta="${{ steps.get_repometa.outputs.date }}"
-            --output="./${{ env.builddir }}/${{ env.prefix }}.html"
+            --output="./${{ env.builddir }}/${{ env.prefix }}-${{ steps.get_repometa.outputs.short_sha }}.html"
             "./${{ env.srcdir }}/${{ env.srcdoc }}"
 
       - name: Upload build artifacts

--- a/.github/workflows/20-release.yaml
+++ b/.github/workflows/20-release.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: "`release` triggered by `build` workflow {{ github.event.workflow_run.id }}"
+      - name: "`release` triggered by `build` workflow ${{ github.event.workflow_run.id }}"
         run: |
           cat <<-__END__
           workflow-run-event: ${{ toJson(github.event.workflow_run) }}
@@ -74,7 +74,7 @@ jobs:
           tag_name: release/${{ steps.get_repometa.outputs.short_sha }}
           release_name: release/${{ steps.get_repometa.outputs.short_sha }}
           prerelease: ${{github.event.workflow_run.head_branch != 'main'}}
-          draft: true
+          draft: ${{github.event.workflow_run.head_branch != 'main'}}
 
       - name: Release Markdown assets
         uses: actions/upload-release-asset@v1


### PR DESCRIPTION
include the git short SHA in artifact filenames, and enable the `release` workflow to generate public releases.